### PR TITLE
launch a single bus instance per container

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A block that provides dbus allowing communication among services. Unlike the hos
 
 ## How to use
 
-Add the dbus block as a service in your docker-compose file
+Add the dbus block as a service in your docker-compose file to start a single bus. The default is to start a bus with the "session" bus config on TCP port 55884.
 
 ```yml
 version: "2"
@@ -12,21 +12,32 @@ services:
   dbus:
     image: balenablocks/dbus
     restart: always
-    privileged: true
 ```
 
-The block exposes the following buses over tcp
+You can also start a bus with the "system" config by overriding the `DBUS_CONFIG` environment variable.
 
-- Session bus
-- System bus
+```yml
+version: "2"
+services:
+  dbus-session:
+    image: balenablocks/dbus
+    restart: always
+    environment:
+      - DBUS_CONFIG: session.conf
+  dbus-system:
+    image: balenablocks/dbus
+    restart: always
+    environment:
+      - DBUS_CONFIG: system.conf
+```
 
-You need to configure the services where you need dbus to use the blocks address
+Configure your services requiring access to dbus to use the TCP addresses of the containers providing the busses
 
 Example:
 
 ```bash
-export DBUS_SESSION_BUS_ADDRESS=tcp:host=dbus,port=55884
-export DBUS_SYSTEM_BUS_ADDRESS=tcp:host=dbus,port=55887
+export DBUS_SESSION_BUS_ADDRESS=tcp:host=dbus-session,port=55884
+export DBUS_SYSTEM_BUS_ADDRESS=tcp:host=dbus-system,port=55884
 ```
 
 ## Customization
@@ -52,5 +63,4 @@ CMD [ "/bin/bash", "/usr/src/mystartscript.sh" ]
 
 | Environment variable | Description                               | Default | Options |
 | -------------------- | ----------------------------------------- | ------- | ------- |
-| `DBUS_SESSION_PORT`  | The port on which the session bus listens | 55884   | -       |
-| `DBUS_SESSION_PORT`  | The port on which the system bus listens  | 55887   | -       |
+| `DBUS_PORT`          | The port on which the bus listens         | 55884   | -       |

--- a/entry.sh
+++ b/entry.sh
@@ -2,11 +2,10 @@
 
 echo "balenaBlocks dbus version: $(cat VERSION)"
 
-SESSION_PORT=${DBUS_SESSION_PORT:-55884}
-SYSTEM_PORT=${DBUS_SYSTEM_PORT:-55887}
+PORT=${DBUS_PORT:-55884}
+CONFIG=${DBUS_CONFIG:-"session.conf"}
 
-dbus-daemon --config-file=/usr/src/app/system.conf --fork --address=tcp:host=0.0.0.0,bind=0.0.0.0,port=$SYSTEM_PORT --print-address 
-
-dbus-daemon --config-file=/usr/src/app/session.conf --address=tcp:host=0.0.0.0,bind=0.0.0.0,port=$SESSION_PORT --print-address
-
-balena-idle
+dbus-daemon --config-file=/usr/src/app/$CONFIG \
+	    --fork \
+	    --address=tcp:host=0.0.0.0,bind=0.0.0.0,port=$PORT \
+	    --print-address

--- a/example/custom-service/start.sh
+++ b/example/custom-service/start.sh
@@ -2,9 +2,7 @@
 
 echo "Starting service..."
 
-# export DBUS_SESSION_BUS_ADDRESS=tcp:host=0.0.0.0,port=55884
 export DBUS_SESSION_BUS_ADDRESS=tcp:host=dbus,port=55884
-# export DBUS_SESSION_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
 
 python service.py
 


### PR DESCRIPTION
Launch only a single bus instance per container. Add variables to allow
for overriding the bus config file, as well as port, so that multiple
bus instances can be launched by adding multiple containers based on the
dbus block.

Signed-off-by: Joseph Kogut <joseph@balena.io>